### PR TITLE
Fix sending cookies - enable withCredentials in XMLHttpRequest polyfill if needed.

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -195,6 +195,9 @@ Request.prototype.fetch = function () {
                 xhr.setRequestHeader(name, value);
             });
         });
+        if (!!self.credentials) {
+            xhr.withCredentials = true;
+        }
 
         xhr.send((self._body === undefined) ? null : self._body);
     });


### PR DESCRIPTION
Set withCredentials=true in XMLHttpRequest object if fetch option "credentials"
is set.